### PR TITLE
Updates/fixes since 1.15.0

### DIFF
--- a/Altoholic/Altoholic.lua
+++ b/Altoholic/Altoholic.lua
@@ -664,7 +664,9 @@ function addon:UpdateSlider(frame, text, field)
 	local name = frame:GetName()
 	local value = frame:GetValue()
 
-	_G[name .. "Text"]:SetText(format("%s (%d)", text, value))
+	if _G[name .. "Text"] then
+		_G[name .. "Text"]:SetText(format("%s (%d)", text, value))
+	end
 	if addon.db and addon.db.global then 
 		addon:SetOption(field, value)
 		Minimap.AltoholicButton:Move()

--- a/Altoholic/Altoholic.toc
+++ b/Altoholic/Altoholic.toc
@@ -9,7 +9,7 @@
 ## Notes-koKR: 부캐들(alts)의 정보들을 제공해 줍니다.
 
 ## Author: Thaoky (EU-Marécages de Zangar)
-## Version: 1.15.007-bugfix
+## Version: 1.15.007
 ## X-Category: Inventory, Tradeskill, Mail
 ## X-Localizations: enUS, frFR, zhCN, zhTW, deDE, koKR, esES, esMX, ruRU
 ## X-Website: http://wow.curse.com/downloads/wow-addons/details/altoholic.aspx

--- a/Altoholic/Altoholic.toc
+++ b/Altoholic/Altoholic.toc
@@ -1,4 +1,4 @@
-## Interface: 11505
+## Interface: 11506
 ## Title: Altoholic Classic by |cFF69CCF0Thaoky|r
 ## Title-zhCN: |cffeedd99 [物品] |r: 全角色统计 Altoholic
 
@@ -9,12 +9,12 @@
 ## Notes-koKR: 부캐들(alts)의 정보들을 제공해 줍니다.
 
 ## Author: Thaoky (EU-Marécages de Zangar)
-## Version: 1.15.007
+## Version: 1.15.007-bugfix
 ## X-Category: Inventory, Tradeskill, Mail
 ## X-Localizations: enUS, frFR, zhCN, zhTW, deDE, koKR, esES, esMX, ruRU
-## X-Website: 
+## X-Website: http://wow.curse.com/downloads/wow-addons/details/altoholic.aspx
 ## X-eMail: thaoky.altoholic@yahoo.com
-## X-Donate: 
+## X-Donate: http://wow.curse.com/downloads/wow-addons/details/altoholic.aspx
 ## X-Credits: My guild (Odysseüs), all translators, the wowace community, and all users for their invaluable suggestions !
 ## Dependencies: DataStore, DataStore_Characters
 
@@ -33,6 +33,9 @@ Core.lua
 Services\Services.xml
 Templates\UITemplates.xml
 Altoholic.xml
+
+# Workaround because of Blizzard
+#Frames\SliderTemplates.xml
 
 Frames\MessageBox.xml
 Frames\TabOptions.xml

--- a/Altoholic/Altoholic.toc
+++ b/Altoholic/Altoholic.toc
@@ -1,4 +1,4 @@
-## Interface: 11500
+## Interface: 11505
 ## Title: Altoholic Classic by |cFF69CCF0Thaoky|r
 ## Title-zhCN: |cffeedd99 [物品] |r: 全角色统计 Altoholic
 
@@ -12,9 +12,9 @@
 ## Version: 1.15.007
 ## X-Category: Inventory, Tradeskill, Mail
 ## X-Localizations: enUS, frFR, zhCN, zhTW, deDE, koKR, esES, esMX, ruRU
-## X-Website: http://wow.curse.com/downloads/wow-addons/details/altoholic.aspx
+## X-Website: 
 ## X-eMail: thaoky.altoholic@yahoo.com
-## X-Donate: http://wow.curse.com/downloads/wow-addons/details/altoholic.aspx
+## X-Donate: 
 ## X-Credits: My guild (Odysseüs), all translators, the wowace community, and all users for their invaluable suggestions !
 ## Dependencies: DataStore, DataStore_Characters
 

--- a/Altoholic/Altoholic.toc
+++ b/Altoholic/Altoholic.toc
@@ -34,9 +34,6 @@ Services\Services.xml
 Templates\UITemplates.xml
 Altoholic.xml
 
-# Workaround because of Blizzard
-#Frames\SliderTemplates.xml
-
 Frames\MessageBox.xml
 Frames\TabOptions.xml
 Frames\MinimapButton.xml

--- a/Altoholic/Frames/TabOptions.lua
+++ b/Altoholic/Frames/TabOptions.lua
@@ -255,7 +255,7 @@ function addon:SetupOptions()
 	-- create categories in Blizzard's options panel
 	
 	DataStore:AddOptionCategory(AltoholicGeneralOptions, addonName)
-	LibStub("LibAboutPanel").new(addonName, addonName);
+	--LibStub("LibAboutPanel").new(addonName, addonName);
 	DataStore:AddOptionCategory(AltoholicHelp, HELP_LABEL, addonName)
 	DataStore:AddOptionCategory(AltoholicSupport, "Getting support", addonName)
 	DataStore:AddOptionCategory(AltoholicWhatsNew, "What's new?", addonName)
@@ -531,8 +531,8 @@ local lastOptionsPanelWidth = 0
 local lastOptionsPanelHeight = 0
 
 function addon:OnUpdate(self, mandatoryResize)
-	OptionsPanelWidth = InterfaceOptionsFramePanelContainer:GetWidth()
-	OptionsPanelHeight = InterfaceOptionsFramePanelContainer:GetHeight()
+	OptionsPanelWidth = SettingsPanel.Container.SettingsCanvas:GetWidth()
+	OptionsPanelHeight = SettingsPanel.Container.SettingsCanvas:GetHeight()
 	
 	if not mandatoryResize then -- if resize is not mandatory, allow exit
 		if OptionsPanelWidth == lastOptionsPanelWidth and OptionsPanelHeight == lastOptionsPanelHeight then return end		-- no size change ? exit

--- a/Altoholic/Frames/TabOptions.xml
+++ b/Altoholic/Frames/TabOptions.xml
@@ -69,7 +69,7 @@
 				</Scripts>
 			</CheckButton>
 			
-			<CheckButton parentKey="ShowMinimapIcon" inherits="InterfaceOptionsCheckButtonTemplate">
+			<CheckButton parentKey="ShowMinimapIcon" inherits="UICheckButtonTemplate">
 				<Size x="20" y="20" />
 				<Anchors> 
 					<Anchor point="TOPLEFT" relativeKey="$parent.ClampWindowToScreen" relativePoint="BOTTOMLEFT" x="0" y="-10" />
@@ -86,7 +86,8 @@
 					</OnClick>
 				</Scripts>
 			</CheckButton>
-			<Slider name="$parent_SliderAngle" inherits="OptionsSliderTemplate"  minValue="1" maxValue="360" defaultValue="180" valueStep="1">
+			<!-- <Slider name="$parent_SliderAngle" inherits="OptionsSliderTemplate"  minValue="1" maxValue="360" defaultValue="180" valueStep="1"> -->
+			<Slider name="$parent_SliderAngle" inherits="UISliderTemplateWithLabels"  minValue="1" maxValue="360" defaultValue="180" valueStep="1">
 				<Size x="180" y="16" />
 				<Anchors>
 					<Anchor point="TOPLEFT" relativeKey="$parent.ShowMinimapIcon" relativePoint="BOTTOMLEFT" x="20" y="-30" />
@@ -98,7 +99,8 @@
 					</OnValueChanged>
 				</Scripts>
 			</Slider>
-			<Slider name="$parent_SliderRadius" inherits="OptionsSliderTemplate"  minValue="1" maxValue="200" defaultValue="78" valueStep="1">
+			<!-- <Slider name="$parent_SliderRadius" inherits="OptionsSliderTemplate"  minValue="1" maxValue="200" defaultValue="78" valueStep="1"> -->
+			<Slider name="$parent_SliderRadius" inherits="UISliderTemplateWithLabels"  minValue="1" maxValue="200" defaultValue="78" valueStep="1">
 				<Size x="180" y="16" />
 				<Anchors>
 					<Anchor point="TOPLEFT" relativeKey="$parent.ShowMinimapIcon" relativePoint="BOTTOMLEFT" x="20" y="-80" />
@@ -111,7 +113,8 @@
 				</Scripts>
 			</Slider>
 			
-			<Slider name="$parent_SliderScale" inherits="OptionsSliderTemplate"  minValue="0.5" maxValue="4.0" defaultValue="1.0" valueStep="0.1">
+			<!-- <Slider name="$parent_SliderScale" inherits="OptionsSliderTemplate"  minValue="0.5" maxValue="4.0" defaultValue="1.0" valueStep="0.1"> -->
+			<Slider name="$parent_SliderScale" inherits="UISliderTemplateWithLabels"  minValue="0.5" maxValue="4.0" defaultValue="1.0" valueStep="0.1">
 				<Size x="180" y="16" />
 				<Anchors>
 					<Anchor point="TOPLEFT" relativeKey="$parent.ShowMinimapIcon" relativePoint="BOTTOMLEFT" x="20" y="-130" />
@@ -158,7 +161,8 @@
 					</OnClick>
 				</Scripts>
 			</Button>
-			<Slider name="$parent_SliderAlpha" inherits="OptionsSliderTemplate"  minValue="0.1" maxValue="1" defaultValue="1" valueStep="0.05">
+			<!-- <Slider name="$parent_SliderAlpha" inherits="OptionsSliderTemplate"  minValue="0.1" maxValue="1" defaultValue="1" valueStep="0.05"> -->
+			<Slider name="$parent_SliderAlpha" inherits="UISliderTemplateWithLabels"  minValue="0.1" maxValue="1" defaultValue="1" valueStep="0.05">
 				<Size x="180" y="16" />
 				<Anchors>
 					<Anchor point="TOPLEFT" relativeKey="$parent.ShowMinimapIcon" relativePoint="BOTTOMLEFT" x="20" y="-210" />
@@ -534,7 +538,7 @@
 				<NormalTexture name="$parentIcon" file="Interface\Buttons\UI-MinusButton-UP" />
 				<HighlightTexture file="Interface\Buttons\UI-PlusButton-Hilight" alphaMode="ADD" />
 			</Button>
-			<CheckButton name="$parent_CheckAll" inherits="InterfaceOptionsSmallCheckButtonTemplate">
+			<CheckButton name="$parent_CheckAll" inherits="UICheckButtonTemplate">
 				<Size x="20" y="20" />
 				<Anchors> 
 					<Anchor point="LEFT" relativeTo="$parent_ToggleAll" relativePoint="RIGHT" x="5" y="0" />

--- a/Altoholic/Frames/TabOptions.xml
+++ b/Altoholic/Frames/TabOptions.xml
@@ -86,7 +86,6 @@
 					</OnClick>
 				</Scripts>
 			</CheckButton>
-			<!-- <Slider name="$parent_SliderAngle" inherits="OptionsSliderTemplate"  minValue="1" maxValue="360" defaultValue="180" valueStep="1"> -->
 			<Slider name="$parent_SliderAngle" inherits="UISliderTemplateWithLabels"  minValue="1" maxValue="360" defaultValue="180" valueStep="1">
 				<Size x="180" y="16" />
 				<Anchors>
@@ -99,7 +98,6 @@
 					</OnValueChanged>
 				</Scripts>
 			</Slider>
-			<!-- <Slider name="$parent_SliderRadius" inherits="OptionsSliderTemplate"  minValue="1" maxValue="200" defaultValue="78" valueStep="1"> -->
 			<Slider name="$parent_SliderRadius" inherits="UISliderTemplateWithLabels"  minValue="1" maxValue="200" defaultValue="78" valueStep="1">
 				<Size x="180" y="16" />
 				<Anchors>
@@ -113,7 +111,6 @@
 				</Scripts>
 			</Slider>
 			
-			<!-- <Slider name="$parent_SliderScale" inherits="OptionsSliderTemplate"  minValue="0.5" maxValue="4.0" defaultValue="1.0" valueStep="0.1"> -->
 			<Slider name="$parent_SliderScale" inherits="UISliderTemplateWithLabels"  minValue="0.5" maxValue="4.0" defaultValue="1.0" valueStep="0.1">
 				<Size x="180" y="16" />
 				<Anchors>
@@ -161,7 +158,6 @@
 					</OnClick>
 				</Scripts>
 			</Button>
-			<!-- <Slider name="$parent_SliderAlpha" inherits="OptionsSliderTemplate"  minValue="0.1" maxValue="1" defaultValue="1" valueStep="0.05"> -->
 			<Slider name="$parent_SliderAlpha" inherits="UISliderTemplateWithLabels"  minValue="0.1" maxValue="1" defaultValue="1" valueStep="0.05">
 				<Size x="180" y="16" />
 				<Anchors>

--- a/Altoholic/libs/LibCraftInfo-1.0/LibCraftInfo.lua
+++ b/Altoholic/libs/LibCraftInfo-1.0/LibCraftInfo.lua
@@ -1,5 +1,5 @@
 --[[	*** LibCraftInfo ***
-Written by : Thaoky, EU-Marécages de Zangar
+Written by : Thaoky, EU-Marï¿½cages de Zangar
 September 21st, 2013
 
 This library contains various information about crafts, namely:
@@ -14,6 +14,7 @@ local LIB_VERSION_MAJOR, LIB_VERSION_MINOR = "LibCraftInfo-1.0", 3
 local lib = LibStub:NewLibrary(LIB_VERSION_MAJOR, LIB_VERSION_MINOR)
 
 if not lib then return end -- No upgrade needed
+local isRetail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
 
 --[[ ** Data Format **
 format [spellID] = attribute (number, to be read bit by bit)
@@ -65,7 +66,7 @@ local internalIDToProfession = {
 	[4] = 45357,	-- Inscription
 	[5] = 25229,	-- Jewelcrafting
 	[6] = 2108,		-- Leatherworking
-	[7] = 2656,		-- Mining
+	[7] = isRetail and 2656 or 2575,		-- Mining
 	[8] = 3908,		-- Tailoring
 	[9] = 2550,		-- Cooking
 	[10] = 3273,	-- First Aid

--- a/Altoholic_Agenda/Altoholic_Agenda.toc
+++ b/Altoholic_Agenda/Altoholic_Agenda.toc
@@ -1,4 +1,4 @@
-## Interface: 11500
+## Interface: 11506
 ## Title: Altoholic_Agenda
 ## Notes: Altoholic's Agenda UI
 ## Author: Thaoky (EU-Marécages de Zangar)

--- a/Altoholic_Characters/Altoholic_Characters.toc
+++ b/Altoholic_Characters/Altoholic_Characters.toc
@@ -1,4 +1,4 @@
-## Interface: 11500
+## Interface: 11506
 ## Title: Altoholic_Characters
 ## Notes: Altoholic's Characters UI
 ## Author: Thaoky (EU-Marécages de Zangar)

--- a/Altoholic_Characters/TabCharacters.lua
+++ b/Altoholic_Characters/TabCharacters.lua
@@ -485,7 +485,7 @@ local function QuestsIcon_Initialize(self, level)
 	DDM_AddTitle("|r ")
 	DDM_AddTitle(GAMEOPTIONS_MENU)
 	if DataStore_Quests then
-		DDM_Add("DataStore Quests", nil, function() Altoholic:ToggleUI(); InterfaceOptionsFrame_OpenToCategory("DataStore_Quests") end)
+		DDM_Add("DataStore Quests", nil, function() Altoholic:ToggleUI(); Settings.OpenToCategory("DataStore_Quests") end)
 	end
 	DDM_AddCloseMenu()
 end
@@ -529,7 +529,7 @@ local function AuctionIcon_Initialize(self, level)
 	DDM_AddTitle("|r ")
 	DDM_AddTitle(GAMEOPTIONS_MENU)
 	if DataStore_Auctions then
-		DDM_Add("DataStore Auctions", nil, function() Altoholic:ToggleUI(); InterfaceOptionsFrame_OpenToCategory("DataStore_Auctions") end)
+		DDM_Add("DataStore Auctions", nil, function() Altoholic:ToggleUI(); Settings.OpenToCategory("DataStore_Auctions") end)
 	end
 	DDM_AddCloseMenu()
 end
@@ -551,9 +551,9 @@ local function MailIcon_Initialize(self, level)
 	DDM_Add(colors.white .. L["Clear all entries"], nil, OnClearMailboxEntries)
 	DDM_AddTitle("|r ")
 	DDM_AddTitle(GAMEOPTIONS_MENU)
-	DDM_Add(MAIL_LABEL, nil, function() Altoholic:ToggleUI(); InterfaceOptionsFrame_OpenToCategory(AltoholicMailOptions) end)
+	DDM_Add(MAIL_LABEL, nil, function() Altoholic:ToggleUI(); Settings.OpenToCategory(AltoholicMailOptions) end)
 	if DataStore_Mails then
-		DDM_Add("DataStore Mails", nil, function() Altoholic:ToggleUI(); InterfaceOptionsFrame_OpenToCategory(DataStoreMailOptions) end)
+		DDM_Add("DataStore Mails", nil, function() Altoholic:ToggleUI(); Settings.OpenToCategory(DataStoreMailOptions) end)
 	end
 	
 	DDM_AddCloseMenu()

--- a/Altoholic_Grids/Altoholic_Grids.toc
+++ b/Altoholic_Grids/Altoholic_Grids.toc
@@ -1,4 +1,4 @@
-## Interface: 11500
+## Interface: 11506
 ## Title: Altoholic_Grids
 ## Notes: Altoholic's Grids Tab
 ## Author: Thaoky (EU-Marécages de Zangar)

--- a/Altoholic_Grids/Grid_Tradeskills.lua
+++ b/Altoholic_Grids/Grid_Tradeskills.lua
@@ -140,7 +140,7 @@ local callbacks = {
 				return
 			end
 			
-			currentItemID = DataStore:GetCraftResultItem(spellID)
+			currentItemID = LCI:GetCraftResultItem(spellID)
 
 			local orange, yellow, green, grey = LCL:GetCraftLevels(spellID)
 			
@@ -172,9 +172,9 @@ local callbacks = {
 			local text = icons.notReady
 			local vc = 0.25	-- vertex color
 			local tradeskills = addon.TradeSkills.spellIDs
-			local profession = DataStore:GetProfession(character, GetSpellInfo(tradeskills[addon:GetOption(OPTION_TRADESKILL)]))			
+			local profession = DataStore:GetProfession(character, GetSpellInfo(tradeskills[addon:GetOption(OPTION_TRADESKILL)]))
 
-			if #profession.Crafts ~= 0 then
+			if profession and #profession.Crafts ~= 0 then
 				-- do not enable this yet .. working fine, but better if more filtering allowed. ==> filtering on rarity
 				
 				-- local _, _, itemRarity, itemLevel = GetItemInfo(currentItemID)
@@ -183,8 +183,8 @@ local callbacks = {
 					-- button.IconBorder:SetVertexColor(r, g, b, 0.5)
 					-- button.IconBorder:Show()
 				-- end
-				
-				if DataStore:IsCraftKnown(profession, currentList[dataRowID]) then
+				--if DataStore:IsCraftKnown(profession, currentList[dataRowID]) then
+				if DataStore:IsCraftKnown(profession, LCI:GetCraftResultItem(currentList[dataRowID])) then
 					vc = 1.0
 					text = icons.ready
 				else

--- a/Altoholic_Grids/Grid_Tradeskills.lua
+++ b/Altoholic_Grids/Grid_Tradeskills.lua
@@ -183,7 +183,6 @@ local callbacks = {
 					-- button.IconBorder:SetVertexColor(r, g, b, 0.5)
 					-- button.IconBorder:Show()
 				-- end
-				--if DataStore:IsCraftKnown(profession, currentList[dataRowID]) then
 				if DataStore:IsCraftKnown(profession, LCI:GetCraftResultItem(currentList[dataRowID])) then
 					vc = 1.0
 					text = icons.ready

--- a/Altoholic_Grids/Grid_Tradeskills.lua
+++ b/Altoholic_Grids/Grid_Tradeskills.lua
@@ -16,7 +16,7 @@ local OPTION_XPACK = "UI.Tabs.Grids.Tradeskills.CurrentXPack"
 local OPTION_TRADESKILL = "UI.Tabs.Grids.Tradeskills.CurrentTradeSkill"
 
 local currentDDMText
-local currentItemID
+local currentItemID = 0
 local currentList
 local dropDownFrame
 
@@ -118,7 +118,7 @@ local callbacks = {
 			local tradeskills = addon.TradeSkills.spellIDs
 			local currentXPack = addon:GetOption(OPTION_XPACK)
 			local currentTradeSkill = addon:GetOption(OPTION_TRADESKILL)
-			
+
 			currentList = LCI:GetProfessionCraftList(tradeskills[currentTradeSkill], currentXPack)
 			if not currentList.isSorted then
 				table.sort(currentList, SortByCraftLevel)
@@ -141,6 +141,7 @@ local callbacks = {
 			end
 			
 			currentItemID = DataStore:GetCraftResultItem(spellID)
+
 			local orange, yellow, green, grey = LCL:GetCraftLevels(spellID)
 			
 			if orange then
@@ -166,8 +167,7 @@ local callbacks = {
 			button.Name:SetPoint("BOTTOMRIGHT", 5, 0)
 			button.Background:SetDesaturated(false)
 			button.Background:SetTexCoord(0, 1, 0, 1)
-			
-			button.Background:SetTexture(GetItemIcon(currentItemID) or ICON_QUESTIONMARK)
+			button.Background:SetTexture((currentItemID and C_Item.GetItemIconByID(currentItemID)) or ICON_QUESTIONMARK)
 
 			local text = icons.notReady
 			local vc = 0.25	-- vertex color

--- a/Altoholic_Guild/Altoholic_Guild.toc
+++ b/Altoholic_Guild/Altoholic_Guild.toc
@@ -1,4 +1,4 @@
-## Interface: 11500
+## Interface: 11506
 ## Title: Altoholic_Guild
 ## Notes: Altoholic's Guild UI
 ## Author: Thaoky (EU-Marécages de Zangar)

--- a/Altoholic_Search/Altoholic_Search.toc
+++ b/Altoholic_Search/Altoholic_Search.toc
@@ -1,4 +1,4 @@
-## Interface: 11500
+## Interface: 11506
 ## Title: Altoholic_Search
 ## Notes: Altoholic's Search UI
 ## Author: Thaoky (EU-Marécages de Zangar)

--- a/Altoholic_Summary/Altoholic_Summary.toc
+++ b/Altoholic_Summary/Altoholic_Summary.toc
@@ -1,4 +1,4 @@
-## Interface: 11500
+## Interface: 11506
 ## Title: Altoholic_Summary
 ## Notes: Altoholic's Summary Tab
 ## Author: Thaoky (EU-Marécages de Zangar)

--- a/Altoholic_Summary/TabSummary.xml
+++ b/Altoholic_Summary/TabSummary.xml
@@ -121,7 +121,7 @@
 				<Scripts>
 					<OnClick>
 						Altoholic:ToggleUI()
-						InterfaceOptionsFrame_OpenToCategory("DataStore")
+						Settings.OpenToCategory("DataStore")
 					</OnClick>
 				</Scripts>
 			</Button>
@@ -135,7 +135,7 @@
 				<Scripts>
 					<OnClick>
 						Altoholic:ToggleUI()
-						InterfaceOptionsFrame_OpenToCategory("Altoholic")
+						Settings.OpenToCategory("Altoholic")
 					</OnClick>
 				</Scripts>
 			</Button>

--- a/Altoholic_Summary/Templates/TabSummaryIcon.lua
+++ b/Altoholic_Summary/Templates/TabSummaryIcon.lua
@@ -50,7 +50,6 @@ end
 
 local function ShowOptionsCategory(self)
 	addon:ToggleUI()
-	--InterfaceOptionsFrame_OpenToCategory(self.value)
 	Settings.OpenToCategory(self.value)
 end
 

--- a/Altoholic_Summary/Templates/TabSummaryIcon.lua
+++ b/Altoholic_Summary/Templates/TabSummaryIcon.lua
@@ -50,7 +50,8 @@ end
 
 local function ShowOptionsCategory(self)
 	addon:ToggleUI()
-	InterfaceOptionsFrame_OpenToCategory(self.value)
+	--InterfaceOptionsFrame_OpenToCategory(self.value)
+	Settings.OpenToCategory(self.value)
 end
 
 local function ResetAllData_MsgBox_Handler(self, button)


### PR DESCRIPTION
Updated WoW version for for all TOCs.

Changes:

- Slider text nil object check
- Removed calls to LibPanel (left commented for possible later use)
- Migrated InterfaceOptions to Settings (possibly incomplete, but functional)
- Migrated to using UICheckButtonTemplate for buttons
- Migrated to using UISliderTemplateWithLabels for sliders
- Updated LibCraftInfo to check for different 'Mining' spellID
- Used LibCraftInfo instead of DataStore for several profession calls
- 